### PR TITLE
DEB-122169: Adding message-level "acting block length"

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
@@ -1863,6 +1863,7 @@ public class CppGenerator implements CodeGenerator
             "        m_bufferLength(bufferLength),\n" +
             "        m_offset(offset),\n" +
             "        m_position(sbeCheckPosition(offset + actingBlockLength)),\n" +
+            "        m_actingBlockLength(actingBlockLength),\n" +
             "        m_actingVersion(actingVersion)\n" +
             "    {\n" +
             "    }\n\n" +
@@ -1897,6 +1898,7 @@ public class CppGenerator implements CodeGenerator
             "    std::uint64_t m_bufferLength = 0;\n" +
             "    std::uint64_t m_offset = 0;\n" +
             "    std::uint64_t m_position = 0;\n" +
+            "    std::uint64_t m_actingBlockLength = 0;\n" +
             "    std::uint64_t m_actingVersion = 0;\n\n" +
 
             "    inline std::uint64_t *sbePositionPtr() SBE_NOEXCEPT\n" +
@@ -2519,8 +2521,13 @@ public class CppGenerator implements CodeGenerator
             indent + "friend std::basic_ostream<CharT, Traits>& operator<<(\n" +
             indent + "    std::basic_ostream<CharT, Traits>& builder, %1$s _writer)\n" +
             indent + "{\n" +
+            indent + "    std::uint64_t blockLength = 0;\n" +
+            indent + "    if (_writer.m_actingBlockLength > 0)\n" +
+            indent + "        blockLength = _writer.m_actingBlockLength;\n" +
+            indent + "    else\n" +
+            indent + "        blockLength = _writer.sbeBlockLength();\n" +
             indent + "    %1$s writer(_writer.m_buffer, _writer.m_offset,\n" +
-            indent + "        _writer.m_bufferLength, _writer.sbeBlockLength(), _writer.m_actingVersion);\n" +
+            indent + "        _writer.m_bufferLength, blockLength, _writer.m_actingVersion);\n" +
             indent + "    builder << '{';\n" +
             indent + "    builder << R\"(\"Name\": \"%1$s\", )\";\n" +
             indent + "    builder << R\"(\"sbeTemplateId\": )\";\n" +


### PR DESCRIPTION
DEB-122169: Adding message-level "acting block length" that will be set by "block length" on the wire data.
@tradingtechnologies/orders 

- This change to the TT fork of the 3rd party "simple-binary-encoding" repo, under the "tt-master" branch, is to fix some generated code issues in the "operator<<" function of the generated SBE message header files;
- It was an issue that we saw when CME upgraded their ilink3 SBE protocol in their New Release environment to schema version 6, while we were still running version 5.  v6 messages have additional CME EBS supported new fields;
- CME SBE protocol is supposed to be backwards compatible, as new fields are supposedly added to the end of the message's  non-repeating group block, before the beginning of the repeating groups;
- The additional fields caused the message "operator <<" function to throw exceptions while processing the repeating groups, because the function was constructing a copy of the message using the v5 generated codes' "block length", which was shorter than what we received from CME v6 wire messages;
- The shorter "block length" (the length between the beginning of the message and the beginning of the first repeating group) most likely resulted in incorrect retrieval of the "NumInGroup" field value and the later traversal of the repeating group items to throw "buffer too short for next group index [E108]";
- The fix is to store the message "block length" that we receive from the wire message, which should contain the correct and longer "acting" block length of the new schema version, so that "operator <<" can then use it to construct the copy with the correct block length of the wire message;
- The bug does not affect any other parts of the generated encoding / decoding codes, only the output stream processing in "operator <<".

Locally, I have rebuilt the sbe tool jar file, regenerated CME SBE message header files, rebuilt OC with the new header files, and run CME SBE OC successfully without any exceptions while generating exchange fills.
Merging this soon but feel free to comment.


