### PR TITLE
DEB-126738: revert invalid enum conditions back to exceptions.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,8 +89,6 @@ endif ()
 
 find_package(Threads)
 
-add_definitions(-DTEST_SBE_LIBRARY)
-
 if (UNIX)
     add_compile_options(-Wall -Wpedantic -Wextra -Wno-unused-parameter)
 endif ()

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
@@ -916,10 +916,7 @@ public class CppGenerator implements CodeGenerator
         new Formatter(sb).format(
             "            case %1$s: return NULL_VALUE;\n" +
             "        }\n\n" +
-            "#ifndef TEST_SBE_LIBRARY\n" +
-            "        TTLOG(WARNING, 0) << \"unknown value for enum %1$s [E103]\";\n" +
-            "#endif\n" +
-            "        return NULL_VALUE;\n" +
+            "        throw std::runtime_error(\"%2$s::get() - unknown value for enum %2$s [E103]\");\n" +
             "    }\n",
             encodingToken.encoding().applicableNullValue().toString(),
             enumName);
@@ -2846,10 +2843,7 @@ public class CppGenerator implements CodeGenerator
         new Formatter(sb).format(
             "            case NULL_VALUE: return \"NULL_VALUE\";\n" +
             "        }\n\n" +
-            "#ifndef TEST_SBE_LIBRARY\n" +
-            "        TTLOG(WARNING, 0) << \"unknown value for enum %1$s [E103]\";\n" +
-            "#endif\n" +
-            "        return \"NULL_VALUE\";\n" +
+            "        throw std::runtime_error(\"%1$s::c_str() - unknown value for enum %1$s [E103]:\");\n" +
             "    }\n\n" +
 
             "    template<typename CharT, typename Traits>\n" +


### PR DESCRIPTION
DEB-126738: revert invalid enum conditions back to exceptions.
@tradingtechnologies/orders 

- originally we wanted warnings because we didn't have codes to handle sbe lib throwing exceptions;
- with recent changes in cme_sbe codes to handle sbe lib exceptions, we should revert these to properly catch these situations and handle them in OC codes.